### PR TITLE
More aggressive null value filtering; explicit handling of casting on search

### DIFF
--- a/redbiom/util.py
+++ b/redbiom/util.py
@@ -4,8 +4,12 @@ import click
 NULL_VALUES = {'Not applicable', 'Unknown', 'Unspecified',
                'Missing: Not collected', None,
                'Missing: Not provided',
+               'Missing: Not Provided', 'missing', '',
                'Missing: Restricted access',
-               'null', 'NULL', 'no_data', 'None', 'nan'}
+               'Missing:Not reported',
+               'Missing: Not applicable',
+               'NA', 'null', 'NULL', 'no_data', 'None', 'nan',
+               'NaN'}
 
 
 def from_or_nargs(from_, nargs_variable):


### PR DESCRIPTION
"ph" from Qiita was loaded up with a bunch of weird values. Added more explicit checks for them as we just don't need to store those values, and additionally added a check to catch the issue.

Open question: would it be better to implicitly remove non-float values via `isnumeric`? Or would it be better to `raise`? I'm inclined to think the former as if the user performs "ph > 7" then they are making an statement about the type of the values they care about, in which case removing anything that does not appear to be numeric makes sense. If this gets a :+1: then I'll revise how this is handled.